### PR TITLE
Increasing default polling timeout for consumers - 1000 times a second i...

### DIFF
--- a/src/HumusAmqpModule/Consumer.php
+++ b/src/HumusAmqpModule/Consumer.php
@@ -135,7 +135,7 @@ class Consumer implements ConsumerInterface, LoggerAwareInterface
      * @param int $waitTimeout in microseconds
      * @throws Exception\InvalidArgumentException
      */
-    public function __construct($queues, $idleTimeout = 5.00, $waitTimeout = 1000)
+    public function __construct($queues, $idleTimeout = 5.00, $waitTimeout = 1000000)
     {
         if (!is_array($queues) && !$queues instanceof \Traversable) {
             throw new Exception\InvalidArgumentException(

--- a/src/HumusAmqpModule/Service/ConsumerAbstractServiceFactory.php
+++ b/src/HumusAmqpModule/Service/ConsumerAbstractServiceFactory.php
@@ -68,7 +68,7 @@ class ConsumerAbstractServiceFactory extends AbstractAmqpQueueAbstractServiceFac
         }
 
         $idleTimeout = isset($spec['idle_timeout']) ? $spec['idle_timeout'] : 5.0;
-        $waitTimeout = isset($spec['wait_timeout']) ? $spec['wait_timeout'] : 1000;
+        $waitTimeout = isset($spec['wait_timeout']) ? $spec['wait_timeout'] : 1000000;
 
         $consumer = new Consumer($queues, $idleTimeout, $waitTimeout);
 


### PR DESCRIPTION
...s just an overkill. With just a single worker running (without any messages), polling for messages alone was consuming over 30% CPU on both cores. May be the same could/should be done for RpcServer?
