### PR TITLE
Fix pcntl typo

### DIFF
--- a/src/HumusAmqpModule/Controller/ConsumerController.php
+++ b/src/HumusAmqpModule/Controller/ConsumerController.php
@@ -118,7 +118,7 @@ class ConsumerController extends AbstractConsoleController implements ConsumerMa
     {
         if (!extension_loaded('pcntl')) {
             throw new Exception\ExtensionNotLoadedException(
-                'pnctl extension missing'
+                'pcntl extension missing'
             );
         }
 

--- a/src/HumusAmqpModule/Controller/RpcServerController.php
+++ b/src/HumusAmqpModule/Controller/RpcServerController.php
@@ -110,7 +110,7 @@ class RpcServerController extends AbstractConsoleController
     {
         if (!extension_loaded('pcntl')) {
             throw new Exception\ExtensionNotLoadedException(
-                'pnctl extension missing'
+                'pcntl extension missing'
             );
         }
 


### PR DESCRIPTION
I was using the `humus amqp consumer` command when this exception has been thrown with the wrong pcntl extension name.

I would suggest to add it into the Dependencies  list in the readme (marked as optional) since, also if its a built-in ext, is not assured that PHP was compiled including it and the operating system supports it.

Anyhow thank you for this module! :wink: 