### PR TITLE
Compatibility for zend framework 2.5.3

### DIFF
--- a/src/HumusAmqpModule/Module.php
+++ b/src/HumusAmqpModule/Module.php
@@ -67,7 +67,8 @@ class Module implements
             $factory = function () use ($serviceName, $config, $ns, $configKey, $serviceManager) {
                 $serviceConfig = $config['humus_amqp_module']['plugin_managers'][$configKey];
                 $service = new $serviceName(new Config($serviceConfig));
-                /* @var $service \Zend\ServiceManager\ServiceManager */
+                /* @var $service \Zend\ServiceManager\AbstractPluginManager */
+                $service->setServiceLocator($serviceManager);
                 if ('Connection' == $ns) {
                     $service->addInitializer(function (AMQPConnection $connection) {
                         if (isset($connection->persistent) && true === $connection->persistent) {


### PR DESCRIPTION
By updating Zend Framework to 2.5.3, the module has a bug due to changing in servicemanager package. That the AbstractPluginManager require to set serviceLocator manually. 
With the change below, the module is working as well for ZF2.5.3 as old version.
Thanks for taken time to conside it in advance.
