### PR TITLE
PSR 3 Log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -35,9 +34,9 @@ before_script:
   - composer update --prefer-dist $DEPENDENCIES
 
 script:
-  - ./vendor/bin/phpunit --coverage-clover ./build/clover.xml
+  - composer ci-phpunit
   - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php build/coverage-checker.php build/clover.xml 70; fi"
-  - sh -c "./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/"
+  - composer phpcs
 
 after_script:
  - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^5.4 || ^7.0",
+        "php": "^5.5 || ^7.0",
         "ext-amqp"  : ">=1.7.0",
         "zendframework/zend-console": "^2.3",
         "zendframework/zend-eventmanager": "^2.3",
@@ -20,7 +20,8 @@
         "zendframework/zend-modulemanager": "^2.3",
         "zendframework/zend-servicemanager": "^2.3",
         "zendframework/zend-text": "^2.3",
-        "zendframework/zend-log": "^2.4"
+        "zendframework/zend-log": "^2.6",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.2",
@@ -36,5 +37,16 @@
         "psr-4": {
             "HumusAmqpModule\\": "src/HumusAmqpModule/"
         }
+    },
+    "scripts": {
+        "test": ["@phpunit", "@phpcs"],
+        "ci-test": [
+            "@ci-phpunit",
+            "@phpcs",
+            "php build/coverage-checker.php build/clover.xml 70"
+        ],
+        "phpunit": "phpunit",
+        "ci-phpunit": "phpunit --coverage-clover ./build/clover.xml",
+        "phpcs": "phpcs --standard=PSR2 ./src/ ./tests/"
     }
 }

--- a/src/HumusAmqpModule/Consumer.php
+++ b/src/HumusAmqpModule/Consumer.php
@@ -22,8 +22,8 @@ use AMQPEnvelope;
 use AMQPQueue;
 use ArrayIterator;
 use InfiniteIterator;
-use Zend\Log\LoggerAwareInterface;
-use Zend\Log\LoggerAwareTrait;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerAwareInterface;
 
 /**
  * The consumer attaches to a single queue
@@ -335,7 +335,7 @@ class Consumer implements ConsumerInterface, LoggerAwareInterface
         $callback = $this->getErrorCallback();
 
         if (null === $callback) {
-            $this->getLogger()->err('Exception during handleDelivery: ' . $e->getMessage());
+            $this->logger->error('Exception during handleDelivery: ' . $e->getMessage());
         } else {
             call_user_func_array($callback, [$e, $this]);
         }
@@ -352,7 +352,7 @@ class Consumer implements ConsumerInterface, LoggerAwareInterface
         $callback = $this->getErrorCallback();
 
         if (null === $callback) {
-            $this->getLogger()->err('Exception during flushDeferred: ' . $e->getMessage());
+            $this->logger->error('Exception during flushDeferred: ' . $e->getMessage());
         } else {
             call_user_func_array($callback, [$e, $this]);
         }
@@ -477,7 +477,7 @@ class Consumer implements ConsumerInterface, LoggerAwareInterface
         try {
             $deferredFlushResult = $this->flushDeferred();
         } catch (\Exception $e) {
-            $this->getLogger()->err('Exception during flushDeferred: ' . $e->getMessage());
+            $this->logger->error('Exception during flushDeferred: ' . $e->getMessage());
             $deferredFlushResult = false;
         }
 

--- a/tests/HumusAmqpModuleTest/ConsumerTest.php
+++ b/tests/HumusAmqpModuleTest/ConsumerTest.php
@@ -20,6 +20,7 @@ namespace HumusAmqpModuleTest\Amqp;
 
 use HumusAmqpModule\Consumer;
 use HumusAmqpModule\ConsumerInterface;
+use Prophecy\Argument;
 
 /**
  * Class ConsumerTest
@@ -48,11 +49,10 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
         $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
 
-        $logger = new \Zend\Log\Logger();
-        $writers = new \Zend\Stdlib\SplPriorityQueue();
-        $writers->insert(new \Zend\Log\Writer\Noop(), 0);
-        $logger->setWriters($writers);
-        $consumer->setLogger($logger);
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger->debug(Argument::any());
+        $logger->error(Argument::any());
+        $consumer->setLogger($logger->reveal());
 
         // Create a callback function with a return value set by the data provider.
         $callbackFunction = function () {
@@ -111,11 +111,10 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
 
 
-        $logger = new \Zend\Log\Logger();
-        $writers = new \Zend\Stdlib\SplPriorityQueue();
-        $writers->insert(new \Zend\Log\Writer\Noop(), 0);
-        $logger->setWriters($writers);
-        $consumer->setLogger($logger);
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger->debug(Argument::any());
+        $logger->error(Argument::any());
+        $consumer->setLogger($logger->reveal());
 
         // Create a callback function with a return value set by the data provider.
         $callbackFunction = function () {
@@ -198,15 +197,13 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
         $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
 
-        $logger = $this->getMockBuilder('Zend\Log\LoggerInterface')
-            ->getMock();
-
-        $logger->expects(static::once())->method('err');
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger->error(Argument::any())->shouldBeCalled();
 
         $exception = new \Exception('Test Exception');
 
         $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
-        $consumer->setLogger($logger);
+        $consumer->setLogger($logger->reveal());
         $consumer->handleDeliveryException($exception);
     }
 
@@ -252,15 +249,13 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
         $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
 
-        $logger = $this->getMockBuilder('Zend\Log\LoggerInterface')
-            ->getMock();
-
-        $logger->expects(static::once())->method('err');
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger->error(Argument::any())->shouldBeCalled();
 
         $exception = new \Exception('Test Exception');
 
         $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
-        $consumer->setLogger($logger);
+        $consumer->setLogger($logger->reveal());
         $consumer->handleDeliveryException($exception);
     }
 }

--- a/tests/HumusAmqpModuleTest/RpcServerTest.php
+++ b/tests/HumusAmqpModuleTest/RpcServerTest.php
@@ -3,6 +3,7 @@
 namespace HumusAmqpModuleTest;
 
 use HumusAmqpModule\RpcServer;
+use Prophecy\Argument;
 
 /**
  * Class RpcServerTest
@@ -56,11 +57,10 @@ class RpcServerTest extends \PHPUnit_Framework_TestCase
             return 'response-result';
         });
 
-        $logger = new \Zend\Log\Logger();
-        $writers = new \Zend\Stdlib\SplPriorityQueue();
-        $writers->insert(new \Zend\Log\Writer\Noop(), 0);
-        $logger->setWriters($writers);
-        $rpcServer->setLogger($logger);
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger->debug(Argument::any());
+        $logger->error(Argument::any());
+        $rpcServer->setLogger($logger->reveal());
 
         $amqpQueue->expects($this->once())->method('ack');
 

--- a/tests/HumusAmqpModuleTest/Service/ConsumerAbstractServiceFactoryTest.php
+++ b/tests/HumusAmqpModuleTest/Service/ConsumerAbstractServiceFactoryTest.php
@@ -579,4 +579,47 @@ class ConsumerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->components->createServiceWithName($this->services, 'test-consumer', 'test-consumer');
     }
+
+    /**
+     * @expectedException \HumusAmqpModule\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The logger foo is not a Psr\Log
+     */
+    public function testCreateConsumerWithInvalidLogger()
+    {
+        $config = [
+            'humus_amqp_module' => [
+                'default_connection' => 'default',
+                'exchanges' => [
+                    'demo-exchange' => [
+                        'name' => 'demo-exchange',
+                        'type' => 'direct'
+                    ]
+                ],
+                'queues' => [
+                    'demo-queue' => [
+                        'name' => 'demo-queue',
+                        'exchange' => 'demo-exchange'
+                    ]
+                ],
+                'consumers' => [
+                    'test-consumer' => [
+                        'connection' => 'default',
+                        'queues' => ['demo-queue'],
+                        'auto_setup_fabric' => false,
+                        'callback' => 'invalid-callback',
+                        'logger' => 'foo',
+                        'qos' => [
+                            'prefetchCount' => 10
+                        ]
+                    ],
+                ],
+            ]
+        ];
+
+        $this->prepare($config);
+
+        $this->services->setService('foo', new \stdClass());
+
+        $this->components->createServiceWithName($this->services, 'test-consumer', 'test-consumer');
+    }
 }

--- a/tests/HumusAmqpModuleTest/Service/RpcServerAbstractServiceFactoryTest.php
+++ b/tests/HumusAmqpModuleTest/Service/RpcServerAbstractServiceFactoryTest.php
@@ -148,4 +148,18 @@ class RpcServerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->components->createServiceWithName($this->services, 'test-rpc-server', 'test-rpc-server');
     }
+
+    /**
+     * @expectedException \HumusAmqpModule\Exception\InvalidArgumentException
+     * @expectedExceptionMessage The logger foo is not a Psr\Log
+     */
+    public function testCreateConsumerWithInvalidLogger()
+    {
+        $config = $this->services->get('Config');
+        $config['humus_amqp_module']['rpc_servers']['test-rpc-server']['logger'] = 'foo';
+        $this->services->setService('Config', $config);
+        $this->services->setService('foo', new \stdClass());
+
+        $this->components->createServiceWithName($this->services, 'test-rpc-server', 'test-rpc-server');
+    }
 }


### PR DESCRIPTION
Instead to use Zend/Log, now it's possibile to use another PSR 3 compatible logger now.

- Added PSR 3 compatibility
- Dropped support for php 5.4
- Added composer scripts

Can we consider it to be merged for 0.2.0?
I also would like to do some work to use container-interop and reduce other hard dependencies.