### PR TITLE
Consumer interfaces

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/tests export-ignore
+/build export-ignore
+/docs export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+README.md export-ignore

--- a/src/HumusAmqpModule/Consumer.php
+++ b/src/HumusAmqpModule/Consumer.php
@@ -24,6 +24,7 @@ use ArrayIterator;
 use InfiniteIterator;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * The consumer attaches to a single queue
@@ -173,6 +174,14 @@ class Consumer implements ConsumerInterface, LoggerAwareInterface
         $this->idleTimeout = (float) $idleTimeout;
         $this->waitTimeout = (int) $waitTimeout;
         $this->queues = new InfiniteIterator(new ArrayIterator($q));
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    public function getLogger()
+    {
+        return $this->logger;
     }
 
     /**

--- a/src/HumusAmqpModule/ConsumerCallbackInterface.php
+++ b/src/HumusAmqpModule/ConsumerCallbackInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace HumusAmqpModule;
+
+use AMQPEnvelope;
+use AMQPQueue;
+
+/**
+ * Interface ConsumerCallbackInterface
+ */
+interface ConsumerCallbackInterface
+{
+    /**
+     * @param AMQPEnvelope      $envelope
+     * @param AMQPQueue         $queue
+     * @param ConsumerInterface $consumer
+     * @return mixed
+     */
+    public function onMessage(AMQPEnvelope $envelope, AMQPQueue $queue, ConsumerInterface $consumer);
+}

--- a/src/HumusAmqpModule/ExceptionCallbackInterface.php
+++ b/src/HumusAmqpModule/ExceptionCallbackInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace HumusAmqpModule;
+
+/**
+ * Interface ExceptionCallbackInterface
+ */
+interface ExceptionCallbackInterface
+{
+    /**
+     * @param \Exception        $e
+     * @param ConsumerInterface $consumer
+     *
+     * @return void
+     */
+    public function onDeliveryException(\Exception $e, ConsumerInterface $consumer);
+
+    /**
+     * @param \Exception        $e
+     * @param ConsumerInterface $consumer
+     *
+     * @return void
+     */
+    public function onFlushDeferredException(\Exception $e, ConsumerInterface $consumer);
+}

--- a/src/HumusAmqpModule/FlushDeferredCallbackInterface.php
+++ b/src/HumusAmqpModule/FlushDeferredCallbackInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace HumusAmqpModule;
+
+use AMQPEnvelope;
+use AMQPQueue;
+
+/**
+ * Interface FlushDeferredCallbackInterface
+ */
+interface FlushDeferredCallbackInterface
+{
+    /**
+     * @param ConsumerInterface $consumer
+     * @return mixed
+     */
+    public function onFlushDeferred(ConsumerInterface $consumer);
+}

--- a/tests/HumusAmqpModuleTest/ConsumerTest.php
+++ b/tests/HumusAmqpModuleTest/ConsumerTest.php
@@ -19,7 +19,9 @@
 namespace HumusAmqpModuleTest\Amqp;
 
 use HumusAmqpModule\Consumer;
+use HumusAmqpModule\ConsumerCallbackInterface;
 use HumusAmqpModule\ConsumerInterface;
+use HumusAmqpModule\ExceptionCallbackInterface;
 use Prophecy\Argument;
 
 /**
@@ -28,26 +30,39 @@ use Prophecy\Argument;
  */
 class ConsumerTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Consumer
+     */
+    protected $consumer;
+    /**
+     * @var \Prophecy\Prophecy\ObjectProphecy|\AMQPChannel
+     */
+    protected $channelProphet;
+    /**
+     * @var \Prophecy\Prophecy\ObjectProphecy|\AMQPQueue
+     */
+    protected $queueProphet;
+
+    protected function setUp()
+    {
+        $this->channelProphet = $this->prophesize(\AMQPChannel::class);
+        $this->channelProphet->getPrefetchCount()->shouldBeCalledTimes(1)->willReturn(3);
+
+        $this->queueProphet = $this->prophesize(\AMQPQueue::class);
+        $this->queueProphet->getChannel()->willReturn($this->channelProphet->reveal());
+
+        $this->consumer = new Consumer([$this->queueProphet->reveal()], 1, 1 * 1000 * 500);
+    }
+
     public function testProcessMessage()
     {
-        $amqpChannel = $this->getMockBuilder('AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $consumer = $this->consumer;
 
-        $amqpChannel->expects($this->once())->method('getPrefetchCount')->willReturn(3);
+        $message = $this->prophesize(\AMQPEnvelope::class);
+        $message->getDeliveryTag()->willReturn(null);
+        $message->isRedelivery()->willReturn(false);
 
-        $message = $this->getMockBuilder('AMQPEnvelope')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpQueue = $this->getMockBuilder('AMQPQueue')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
-        $amqpQueue->expects($this->any())->method('get')->willReturn($message);
-
-        $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
+        $this->queueProphet->get()->willReturn($message->reveal());
 
         $logger = $this->prophesize('Psr\Log\LoggerInterface');
         $logger->debug(Argument::any());
@@ -79,37 +94,23 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         };
         $consumer->setDeliveryCallback($callbackFunction);
 
-        $amqpQueue->expects($this->exactly(2))->method('ack');
-        $amqpQueue->expects($this->exactly(3))->method('reject');
+        $this->queueProphet->ack(Argument::any(), Argument::any())->shouldBeCalledTimes(2);
+        $this->queueProphet->reject(Argument::any(), Argument::any())->shouldBeCalledTimes(3);
 
         $consumer->consume(7);
     }
 
     public function testFlushDeferred()
     {
-        $amqpChannel = $this->getMockBuilder('AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $consumer = $this->consumer;
 
-        $amqpChannel->expects($this->once())->method('getPrefetchCount')->willReturn(3);
-
-        $message = $this->getMockBuilder('AMQPEnvelope')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $message->expects($this->any())->method('getDeliveryTag')->willReturnCallback(function () {
-            return uniqid();
+        $message = $this->prophesize(\AMQPEnvelope::class);
+        $message->getDeliveryTag()->will(function() {
+            return uniqid('', true);
         });
+        $message->isRedelivery()->willReturn(false);
 
-        $amqpQueue = $this->getMockBuilder('AMQPQueue')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
-        $amqpQueue->expects($this->any())->method('get')->willReturn($message);
-
-        $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
-
+        $this->queueProphet->get()->willReturn($message->reveal());
 
         $logger = $this->prophesize('Psr\Log\LoggerInterface');
         $logger->debug(Argument::any());
@@ -149,27 +150,28 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
             return false;
         });
 
-        $amqpQueue->expects($this->exactly(3))->method('ack');
-        $amqpQueue->expects($this->exactly(3))->method('reject');
+        $this->queueProphet->ack(Argument::any(), Argument::any())->shouldBeCalledTimes(3);
+        $this->queueProphet->reject(Argument::any(), Argument::any())->shouldBeCalledTimes(3);
 
         $consumer->consume(5);
     }
 
+    public function testHandleDeliveryWithCallbackInterface()
+    {
+        $consumer = $this->consumer;
+
+        $envelope = $this->prophesize(\AMQPEnvelope::class);
+
+        $callback = $this->prophesize(ConsumerCallbackInterface::class);
+        $callback->onMessage($envelope->reveal(), $this->queueProphet->reveal(), $consumer)->shouldBeCalledTimes(1);
+
+        $consumer->setDeliveryCallback($callback->reveal());
+        $consumer->handleDelivery($envelope->reveal(), $this->queueProphet->reveal());
+    }
+
     public function testHandleDeliveryException()
     {
-        $amqpChannel = $this->getMockBuilder('AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpChannel->expects($this->once())->method('getPrefetchCount')->willReturn(3);
-
-        $amqpQueue = $this->getMockBuilder('AMQPQueue')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
-
-        $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
+        $consumer = $this->consumer;
 
         $exception = new \Exception('Test Exception');
         $errorCallback = $this->getMockBuilder('stdClass')
@@ -185,43 +187,31 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleDeliveryExceptionWithLogger()
     {
-        $amqpChannel = $this->getMockBuilder('AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpChannel->expects($this->once())->method('getPrefetchCount')->willReturn(3);
-
-        $amqpQueue = $this->getMockBuilder('AMQPQueue')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
-
         $logger = $this->prophesize('Psr\Log\LoggerInterface');
         $logger->error(Argument::any())->shouldBeCalled();
 
         $exception = new \Exception('Test Exception');
 
-        $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
+        $consumer = $this->consumer;
         $consumer->setLogger($logger->reveal());
+        $consumer->handleDeliveryException($exception);
+    }
+
+    public function testHandleDeliveryExceptionWithCallbackInterface()
+    {
+        $consumer = $this->consumer;
+
+        $exception = new \Exception('Test Exception');
+        $errorCallback = $this->prophesize(ExceptionCallbackInterface::class);
+        $errorCallback->onDeliveryException($exception, $consumer)->shouldBeCalledTimes(1);
+
+        $consumer->setErrorCallback($errorCallback->reveal());
         $consumer->handleDeliveryException($exception);
     }
 
     public function testHandleFlushDeferredException()
     {
-        $amqpChannel = $this->getMockBuilder('AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpChannel->expects($this->once())->method('getPrefetchCount')->willReturn(3);
-
-        $amqpQueue = $this->getMockBuilder('AMQPQueue')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
-
-        $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
+        $consumer = $this->consumer;
 
         $exception = new \Exception('Test Exception');
         $errorCallback = $this->getMockBuilder('stdClass')
@@ -231,31 +221,32 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         $errorCallback->expects(static::once())
             ->method('__invoke')
             ->with($exception, $consumer);
+
         $consumer->setErrorCallback($errorCallback);
         $consumer->handleFlushDeferredException($exception);
     }
 
     public function testHandleFlushDeferredExceptionWithLogger()
     {
-        $amqpChannel = $this->getMockBuilder('AMQPChannel')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpChannel->expects($this->once())->method('getPrefetchCount')->willReturn(3);
-
-        $amqpQueue = $this->getMockBuilder('AMQPQueue')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $amqpQueue->expects($this->once())->method('getChannel')->willReturn($amqpChannel);
-
+        $consumer = $this->consumer;
         $logger = $this->prophesize('Psr\Log\LoggerInterface');
         $logger->error(Argument::any())->shouldBeCalled();
 
         $exception = new \Exception('Test Exception');
 
-        $consumer = new Consumer([$amqpQueue], 1, 1 * 1000 * 500);
         $consumer->setLogger($logger->reveal());
-        $consumer->handleDeliveryException($exception);
+        $consumer->handleFlushDeferredException($exception);
+    }
+
+    public function testHandleFlushDeferredExceptionWithCallbackInterface()
+    {
+        $consumer = $this->consumer;
+
+        $exception = new \Exception('Test Exception');
+        $errorCallback = $this->prophesize(ExceptionCallbackInterface::class);
+        $errorCallback->onFlushDeferredException($exception, $consumer)->shouldBeCalledTimes(1);
+
+        $consumer->setErrorCallback($errorCallback->reveal());
+        $consumer->handleFlushDeferredException($exception);
     }
 }

--- a/tests/HumusAmqpModuleTest/ConsumerTest.php
+++ b/tests/HumusAmqpModuleTest/ConsumerTest.php
@@ -105,7 +105,7 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         $consumer = $this->consumer;
 
         $message = $this->prophesize(\AMQPEnvelope::class);
-        $message->getDeliveryTag()->will(function() {
+        $message->getDeliveryTag()->will(function () {
             return uniqid('', true);
         });
         $message->isRedelivery()->willReturn(false);

--- a/tests/HumusAmqpModuleTest/Controller/ConsumerControllerTest.php
+++ b/tests/HumusAmqpModuleTest/Controller/ConsumerControllerTest.php
@@ -35,7 +35,10 @@ class ConsumerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithTestConsumer()
     {
-        $consumer = $this->getMock('HumusAmqpModule\Consumer', ['consume'], [], '', false);
+        $consumer = $this->getMockBuilder('HumusAmqpModule\Consumer')
+            ->setMethods(['consume'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $consumer
             ->expects($this->once())
             ->method('consume')
@@ -79,7 +82,7 @@ class ConsumerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithInvalidAmount()
     {
-        $consumer = $this->getMock(__NAMESPACE__ . '\TestAsset\TestConsumer');
+        $consumer = $this->getMockBuilder(__NAMESPACE__ . '\TestAsset\TestConsumer')->getMock();
 
         $serviceManager = $this->getApplicationServiceLocator();
         $serviceManager->setAllowOverride(true);

--- a/tests/HumusAmqpModuleTest/Controller/PurgeConsumerControllerTest.php
+++ b/tests/HumusAmqpModuleTest/Controller/PurgeConsumerControllerTest.php
@@ -36,7 +36,9 @@ class PurgeConsumerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithTestConsumer()
     {
-        $consumer = $this->getMock(__NAMESPACE__ . '\TestAsset\TestConsumer', ['purge']);
+        $consumer = $this->getMockBuilder(__NAMESPACE__ . '\TestAsset\TestConsumer')
+            ->setMethods(['purge'])
+            ->getMock();
         $consumer
             ->expects($this->once())
             ->method('purge');
@@ -72,7 +74,7 @@ class PurgeConsumerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testPromptNoResponse()
     {
-        $consumer = $this->getMock(__NAMESPACE__ . '\TestAsset\TestConsumer');
+        $consumer = $this->getMockBuilder(__NAMESPACE__ . '\TestAsset\TestConsumer')->getMock();
 
         $adapter = new ConsoleAdapter();
         $adapter->stream = fopen('php://memory', 'w+');

--- a/tests/HumusAmqpModuleTest/Controller/RpcServerControllerTest.php
+++ b/tests/HumusAmqpModuleTest/Controller/RpcServerControllerTest.php
@@ -34,7 +34,10 @@ class RpcServerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatch()
     {
-        $rpcServer = $this->getMock('HumusAmqpModule\RpcServer', ['consume'], [], '', false);
+        $rpcServer = $this->getMockBuilder('HumusAmqpModule\RpcServer')
+            ->setMethods(['consume'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $rpcServer
             ->expects($this->once())
             ->method('consume')
@@ -53,7 +56,10 @@ class RpcServerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatchWithInvalidAmount()
     {
-        $rpcServer = $this->getMock('HumusAmqpModule\RpcServer', ['consume'], [], '', false);
+        $rpcServer = $this->getMockBuilder('HumusAmqpModule\RpcServer')
+            ->setMethods(['consume'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $rpcServer
             ->expects($this->never())
             ->method('consume');

--- a/tests/HumusAmqpModuleTest/Controller/StdInProducerControllerTest.php
+++ b/tests/HumusAmqpModuleTest/Controller/StdInProducerControllerTest.php
@@ -35,7 +35,9 @@ class StdInProducerControllerTest extends AbstractConsoleControllerTestCase
 
     public function testDispatch()
     {
-        $producer = $this->getMock(__NAMESPACE__ . '\TestAsset\Producer', ['publish']);
+        $producer = $this->getMockBuilder(__NAMESPACE__ . '\TestAsset\Producer')
+            ->setMethods(['publish'])
+            ->getMock();
         $producer
             ->expects($this->once())
             ->method('publish')

--- a/tests/HumusAmqpModuleTest/ModuleTest.php
+++ b/tests/HumusAmqpModuleTest/ModuleTest.php
@@ -48,7 +48,7 @@ class ModuleTest extends ServiceManagerTestCase
     {
         $module = new Module();
 
-        $usage = $module->getConsoleUsage($this->getMock('Zend\Console\Adapter\AdapterInterface'));
+        $usage = $module->getConsoleUsage($this->getMockBuilder('Zend\Console\Adapter\AdapterInterface')->getMock());
 
         $this->assertInternalType('array', $usage);
     }

--- a/tests/HumusAmqpModuleTest/PluginManager/ProducerTest.php
+++ b/tests/HumusAmqpModuleTest/PluginManager/ProducerTest.php
@@ -25,7 +25,9 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
 {
     public function testValidatePlugin()
     {
-        $mock = $this->getMock('HumusAmqpModule\\Producer', [], [], '', false);
+        $mock = $this->getMockBuilder('HumusAmqpModule\\Producer')
+            ->disableOriginalConstructor()
+            ->getMock();
         $manager = new ProducerPluginManager($this->prophesize(ContainerInterface::class)->reveal());
         $manager->validatePlugin($mock);
     }

--- a/tests/HumusAmqpModuleTest/PluginManager/RpcClientTest.php
+++ b/tests/HumusAmqpModuleTest/PluginManager/RpcClientTest.php
@@ -25,7 +25,9 @@ class RpcClientTest extends \PHPUnit_Framework_TestCase
 {
     public function testValidatePlugin()
     {
-        $mock = $this->getMock('HumusAmqpModule\\RpcClient', [], [], '', false);
+        $mock = $this->getMockBuilder('HumusAmqpModule\\RpcClient')
+            ->disableOriginalConstructor()
+            ->getMock();
         $manager = new RpcClientPluginManager($this->prophesize(ContainerInterface::class)->reveal());
         $manager->validatePlugin($mock);
     }

--- a/tests/HumusAmqpModuleTest/PluginManager/RpcServerTest.php
+++ b/tests/HumusAmqpModuleTest/PluginManager/RpcServerTest.php
@@ -25,7 +25,9 @@ class RpcServerTest extends \PHPUnit_Framework_TestCase
 {
     public function testValidatePlugin()
     {
-        $mock = $this->getMock('HumusAmqpModule\\RpcServer', [], [], '', false);
+        $mock = $this->getMockBuilder('HumusAmqpModule\\RpcServer')
+            ->disableOriginalConstructor()
+            ->getMock();
         $manager = new RpcServerPluginManager($this->prophesize(ContainerInterface::class)->reveal());
         $manager->validatePlugin($mock);
     }

--- a/tests/HumusAmqpModuleTest/Service/ConsumerAbstractServiceFactoryTest.php
+++ b/tests/HumusAmqpModuleTest/Service/ConsumerAbstractServiceFactoryTest.php
@@ -38,24 +38,32 @@ class ConsumerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function prepare($config)
     {
-        $connection = $this->getMock('AMQPConnection', [], [], '', false);
-        $channel    = $this->getMock('AMQPChannel', [], [], '', false);
+        $connection = $this->getMockBuilder('AMQPConnection')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $channel    = $this->getMockBuilder('AMQPChannel')
+            ->disableOriginalConstructor()
+            ->getMock();
         $channel
             ->expects($this->any())
             ->method('getPrefetchCount')
             ->will($this->returnValue(10));
-        $queue      = $this->getMock('AMQPQueue', [], [], '', false);
+        $queue      = $this->getMockBuilder('AMQPQueue')
+            ->disableOriginalConstructor()
+            ->getMock();
         $queue
             ->expects($this->any())
             ->method('getChannel')
             ->will($this->returnValue($channel));
-        $queueFactory = $this->getMock('HumusAmqpModule\QueueFactory');
+        $queueFactory = $this->getMockBuilder('HumusAmqpModule\QueueFactory')->getMock();
         $queueFactory
             ->expects($this->any())
             ->method('create')
             ->will($this->returnValue($queue));
 
-        $connectionManager = $this->getMock('HumusAmqpModule\PluginManager\Connection', [], [], '', false);
+        $connectionManager = $this->getMockBuilder('HumusAmqpModule\PluginManager\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connectionManager
             ->expects($this->any())
             ->method('get')

--- a/tests/HumusAmqpModuleTest/Service/ProducerAbstractServiceFactoryTest.php
+++ b/tests/HumusAmqpModuleTest/Service/ProducerAbstractServiceFactoryTest.php
@@ -90,20 +90,22 @@ class ProducerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $connection = $this->getMock('AMQPConnection', [], [], '', false);
-        $channel    = $this->getMock('AMQPChannel', [], [], '', false);
+        $connection = $this->getMockBuilder('AMQPConnection')->disableOriginalConstructor()->getMock();
+        $channel    = $this->getMockBuilder('AMQPChannel')->disableOriginalConstructor()->getMock();
         $channel
             ->expects($this->any())
             ->method('getPrefetchCount')
             ->will($this->returnValue(10));
-        $exchange      = $this->getMock('AMQPExchange', [], [], '', false);
-        $exchangeFactory = $this->getMock('HumusAmqpModule\ExchangeFactory');
+        $exchange      = $this->getMockBuilder('AMQPExchange')->disableOriginalConstructor()->getMock();
+        $exchangeFactory = $this->getMockBuilder('HumusAmqpModule\ExchangeFactory')->getMock();
         $exchangeFactory
             ->expects($this->any())
             ->method('create')
             ->will($this->returnValue($exchange));
 
-        $connectionManager = $this->getMock('HumusAmqpModule\PluginManager\Connection', [], [], '', false);
+        $connectionManager = $this->getMockBuilder('HumusAmqpModule\PluginManager\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connectionManager
             ->expects($this->any())
             ->method('get')

--- a/tests/HumusAmqpModuleTest/Service/RpcClientAbstractServiceFactoryTest.php
+++ b/tests/HumusAmqpModuleTest/Service/RpcClientAbstractServiceFactoryTest.php
@@ -41,24 +41,26 @@ class RpcClientAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $services->setAllowOverride(true);
         $services->setService('config', $config);
 
-        $connection = $this->getMock('AMQPConnection', [], [], '', false);
-        $channel    = $this->getMock('AMQPChannel', [], [], '', false);
+        $connection = $this->getMockBuilder('AMQPConnection')->disableOriginalConstructor()->getMock();
+        $channel    = $this->getMockBuilder('AMQPChannel')->disableOriginalConstructor()->getMock();
         $channel
             ->expects($this->any())
             ->method('getPrefetchCount')
             ->will($this->returnValue(10));
-        $queue      = $this->getMock('AMQPQueue', [], [], '', false);
+        $queue      = $this->getMockBuilder('AMQPQueue')->disableOriginalConstructor()->getMock();
         $queue
             ->expects($this->any())
             ->method('getChannel')
             ->will($this->returnValue($channel));
-        $queueFactory = $this->getMock('HumusAmqpModule\QueueFactory');
+        $queueFactory = $this->getMockBuilder('HumusAmqpModule\QueueFactory')->getMock();
         $queueFactory
             ->expects($this->any())
             ->method('create')
             ->will($this->returnValue($queue));
 
-        $connectionManager = $this->getMock('HumusAmqpModule\PluginManager\Connection', [], [], '', false);
+        $connectionManager = $this->getMockBuilder('HumusAmqpModule\PluginManager\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connectionManager
             ->expects($this->any())
             ->method('get')

--- a/tests/HumusAmqpModuleTest/Service/RpcServerAbstractServiceFactoryTest.php
+++ b/tests/HumusAmqpModuleTest/Service/RpcServerAbstractServiceFactoryTest.php
@@ -66,31 +66,33 @@ class RpcServerAbstractServiceFactoryTest extends \PHPUnit_Framework_TestCase
             ]
         ];
 
-        $connection = $this->getMock('AMQPConnection', [], [], '', false);
-        $channel    = $this->getMock('AMQPChannel', [], [], '', false);
+        $connection = $this->getMockBuilder('AMQPConnection')->disableOriginalConstructor()->getMock();
+        $channel    = $this->getMockBuilder('AMQPChannel')->disableOriginalConstructor()->getMock();
         $channel
             ->expects($this->any())
             ->method('getPrefetchCount')
             ->will($this->returnValue(10));
-        $queue      = $this->getMock('AMQPQueue', [], [], '', false);
+        $queue      = $this->getMockBuilder('AMQPQueue')->disableOriginalConstructor()->getMock();
         $queue
             ->expects($this->any())
             ->method('getChannel')
             ->will($this->returnValue($channel));
-        $queueFactory = $this->getMock('HumusAmqpModule\QueueFactory');
+        $queueFactory = $this->getMockBuilder('HumusAmqpModule\QueueFactory')->getMock();
         $queueFactory
             ->expects($this->any())
             ->method('create')
             ->will($this->returnValue($queue));
 
-        $connectionManager = $this->getMock('HumusAmqpModule\PluginManager\Connection', [], [], '', false);
+        $connectionManager = $this->getMockBuilder('HumusAmqpModule\PluginManager\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
         $connectionManager
             ->expects($this->any())
             ->method('get')
             ->with('default')
             ->willReturn($connection);
 
-        $customLog = $this->getMock('Zend\Log\LoggerInterface');
+        $customLog = $this->getMockBuilder('Zend\Log\LoggerInterface')->getMock();
 
         $services    = $this->services = new ServiceManager();
         $services->setAllowOverride(true);


### PR DESCRIPTION
This PR adds some interfaces to eventually replace single callbacks with a single class.

The problem is that if I want to handle delivery and exceptions, I need to create different callable classes.
With this PR would be possible to do something like that:

```php
return [
    'humus_amqp_module' => [
        'consumers' => [
            'demo-consumer' => [
                'callback' => My\Consumer\Callback::class,
                'flush_callback' => My\Consumer\Callback::class,
                'error_callback' => My\Consumer\Callback::class,
            ]
        ],
        'plugin_managers' => [
            'callback' => [
                'factories' => [
                    My\Consumer\Callback::class => My\Consumer\CallbackFactory::class,
                ]
            ]
        ]
    ]
];
```

And then implementing my single "callback":

```php
namespace My\Consumer;

use AMQPEnvelope;
use AMQPQueue;
use HumusAmqpModule\ConsumerCallbackInterface;
use HumusAmqpModule\ConsumerInterface;
use HumusAmqpModule\ExceptionCallbackInterface;
use HumusAmqpModule\FlushDeferredCallbackInterface;

class Callback implements
    ConsumerCallbackInterface,
    ExceptionCallbackInterface,
    FlushDeferredCallbackInterface
{

    public function onMessage(AMQPEnvelope $envelope, AMQPQueue $queue, ConsumerInterface $consumer)
    {
        // handle
    }

    public function onDeliveryException(\Exception $e, ConsumerInterface $consumer)
    {
        // handle
    }

    public function onFlushDeferredException(\Exception $e, ConsumerInterface $consumer)
    {
        // handle
    }

    public function onFlushDeferred(ConsumerInterface $consumer)
    {
        // handle
    }
}
```

**Other changes:**
- Added `.gitattributes` to exclude files on archive
- Removed deprecated `getMock()` method
- Added `Consumer::getLogger()` to be available to the callbacks
